### PR TITLE
Fix [3110] : Survey reports are not getting generated in the Metabase dashboard.

### DIFF
--- a/stream-jobs/survey-stream-processor/src/main/scala/org/shikshalokam/job/survey/stream/processor/functions/SurveyStreamFunction.scala
+++ b/stream-jobs/survey-stream-processor/src/main/scala/org/shikshalokam/job/survey/stream/processor/functions/SurveyStreamFunction.scala
@@ -246,6 +246,9 @@ class SurveyStreamFunction(config: SurveyStreamConfig)(implicit val mapTypeInfo:
       postgresUtil.checkAndCreateTable(surveyStatusTable, createSurveyStatusTableQuery)
       postgresUtil.executeUpdate(AlterSurveyStatusTableQuery,surveyStatusTable,solutionId)
 
+      postgresUtil.checkAndCreateTable(surveyQuestionTable, createSurveyQuestionsTableQuery)
+      postgresUtil.executeUpdate(AlterSurveyQuestionsTableQuery, surveyQuestionTable, solutionId)
+
       val upsertSurveyDataQuery =
         s"""INSERT INTO $surveyStatusTable (
            |    survey_id, user_id, user_role_ids, user_roles, state_id, state_name, district_id, district_name,
@@ -279,8 +282,6 @@ class SurveyStreamFunction(config: SurveyStreamConfig)(implicit val mapTypeInfo:
       postgresUtil.executePreparedUpdate(upsertSurveyDataQuery, surveyParams, surveyStatusTable, surveyId)
 
       if (event.status == "completed") {
-        postgresUtil.checkAndCreateTable(surveyQuestionTable, createSurveyQuestionsTableQuery)
-        postgresUtil.executeUpdate(AlterSurveyQuestionsTableQuery, surveyQuestionTable, solutionId)
         /**
          * Extracting Survey Questions Data
          */


### PR DESCRIPTION
**Ticket [3110](https://katha.shikshalokam.org/bug-view-3110.html)**

**Issue:**
The survey report was not being generated and appeared empty in the survey collection.

**Root Cause:**
When a survey event with the status `started` was sent to the data pipeline, it triggered processing and pushed a message to the Metabase Kafka topic. At this stage, only the `survey_status` table was created. However, since the `questions` table did not exist, the dashboard creation failed due to missing table dependencies.

**Solution:**
Now, the `questions` table is created even for the `started` status. It acts as a dummy table (without data) to ensure the required schema exists. This allows the dashboard creation process to succeed, even at the `started` stage.