### PR TITLE
added the customised entity type filter creation logic

### DIFF
--- a/metabase-jobs/config-data-loader/projectJson/Observation-Domain/Domain-Report/json/big-number/1_no_of_distinct_count_of_school.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Domain/Domain-Report/json/big-number/1_no_of_distinct_count_of_school.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "select count(distinct(${entityColumnName}))\nFROM ${domainTable}\nWHERE 1 = 1\nAND ${entityColumnName} is not null \nAND ${entityColumnName} <> ''\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]",
+        "query": "select count(distinct(${entityColumnName}))\nFROM ${domainTable}\nWHERE 1 = 1\nAND ${entityColumnName} is not null \nAND ${entityColumnName} <> ''\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\n[[AND {{entity_param}}]]",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -109,6 +109,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -227,6 +241,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -320,6 +347,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Domain/Domain-Report/json/graph/1_domain_chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Domain/Domain-Report/json/graph/1_domain_chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT domain_level,domain as \"Domain\",count(distinct ${entityColumnId}) AS \"Percentage wise distribution of count of ${entityType}\"\nFROM ${domainTable}\nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\nGROUP BY domain_level,domain\norder by domain",
+        "query": "SELECT domain_level,domain as \"Domain\",count(distinct ${entityColumnId}) AS \"Percentage wise distribution of count of ${entityType}\"\nFROM ${domainTable}\nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\n[[AND {{entity_param}}]]\nGROUP BY domain_level,domain\norder by domain",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -109,6 +109,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -237,6 +251,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -330,6 +357,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Domain/Domain-Report/json/graph/2_criteria_chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Domain/Domain-Report/json/graph/2_criteria_chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT criteria_level,criteria as \"Criteria\",count(distinct ${entityColumnName}) as \"Percentage wise distribution of count of ${entityType}\"\nFROM ${domainTable}\nWHERE 1 =1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\nGROUP BY criteria_level,criteria;",
+        "query": "SELECT criteria_level,criteria as \"Criteria\",count(distinct ${entityColumnName}) as \"Percentage wise distribution of count of ${entityType}\"\nFROM ${domainTable}\nWHERE 1 =1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\n[[AND {{entity_param}}]]\nGROUP BY criteria_level,criteria;",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -109,6 +109,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -237,6 +251,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -330,6 +357,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Domain/Domain-Report/json/table/1_domain_criteria_report.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Domain/Domain-Report/json/table/1_domain_criteria_report.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT user_id as \"UUID\",\nuser_roles as \"User Roles\",\nparent_one_name as \"State\",\nparent_two_name as \"District\",\nparent_three_name as \"Block\",\nparent_four_name as \"Cluster\",\norg_name as \"Organisation\",\nprogram_name as \"Program\",\nprogram_id as \"Program Id\",\nobservation_name as \"Observation\",\nobservation_id as \"Observation Id\",\nsubmission_id as \"Observation Submission Id\",\ncompleted_date as \"Submission Date\",\ndomain  as \"Domain\",\ndomain_level as \"Domain Level\",\ncriteria as \"Criteria\",\ncriteria_level as \"criteria_level\"\nFROM ${domainTable}\nWHERE 1 =1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]];",
+        "query": "SELECT user_id as \"UUID\",\nuser_roles as \"User Roles\",\nparent_one_name as \"State\",\nparent_two_name as \"District\",\nparent_three_name as \"Block\",\nparent_four_name as \"Cluster\",\norg_name as \"Organisation\",\nprogram_name as \"Program\",\nprogram_id as \"Program Id\",\nobservation_name as \"Observation\",\nobservation_id as \"Observation Id\",\nsubmission_id as \"Observation Submission Id\",\ncompleted_date as \"Submission Date\",\ndomain  as \"Domain\",\ndomain_level as \"Domain Level\",\ncriteria as \"Criteria\",\ncriteria_level as \"criteria_level\"\nFROM ${domainTable}\nWHERE 1 =1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\n[[AND {{entity_param}}]];",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -109,6 +109,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -237,6 +251,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -330,6 +357,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question-Domain/Question-Report/json/big-number/big-number.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question-Domain/Question-Report/json/big-number/big-number.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "select count(distinct(${entityColumnName}))\nFROM ${domainTable}\nWHERE 1 = 1\nAND ${entityColumnName} is not null \nAND ${entityColumnName} <> ''\nAND parent_one_name in (\n    SELECT parent_one_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{state_param}}]]\n  )\nAND parent_two_name in (\n    SELECT parent_two_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{district_param}}]]\n  )\nAND parent_three_name in (\n    SELECT parent_three_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{block_param}}]]\n  )\nAND parent_four_name in (\n    SELECT parent_four_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{cluster_param}}]]\n  )  \nAND parent_five_name in (\n    SELECT parent_five_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{org_param}}]]\n  ) \nAND domain in (\n    SELECT domain_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{domain_param}}]]\n  )  \nAND criteria in (\n    SELECT criteria_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{criteria_param}}]]\n  )",
+        "query": "select count(distinct(${entityColumnName}))\nFROM ${domainTable}\nWHERE 1 = 1\nAND ${entityColumnName} is not null \nAND ${entityColumnName} <> ''\nAND parent_one_name in (\n    SELECT parent_one_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{state_param}}]]\n  )\nAND parent_two_name in (\n    SELECT parent_two_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{district_param}}]]\n  )\nAND parent_three_name in (\n    SELECT parent_three_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{block_param}}]]\n  )\nAND parent_four_name in (\n    SELECT parent_four_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{cluster_param}}]]\n  )  \nAND parent_five_name in (\n    SELECT parent_five_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{org_param}}]]\n  ) \nAND domain in (\n    SELECT domain_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{domain_param}}]]\n  )  \nAND criteria in (\n    SELECT criteria_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{criteria_param}}]]\n  )\nAND entity_name in (\n    SELECT entity_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{entity_param}}]]\n  )",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -95,6 +95,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -200,6 +214,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -282,6 +309,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question-Domain/Question-Report/json/graph/criteria-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question-Domain/Question-Report/json/graph/criteria-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT criteria_level,criteria as \"Criteria\",count(distinct ${entityColumnName}) as \"Percentage wise distribution of count of ${entityType}\"\nFROM ${domainTable}\nWHERE 1 =1 \nAND parent_one_name in (\n    SELECT parent_one_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{state_param}}]]\n  )\nAND parent_two_name in (\n    SELECT parent_two_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{district_param}}]]\n  )\nAND parent_three_name in (\n    SELECT parent_three_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{block_param}}]]\n  )\nAND parent_four_name in (\n    SELECT parent_four_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{cluster_param}}]]\n  )  \nAND parent_five_name in (\n    SELECT parent_five_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{org_param}}]]\n  ) \nAND domain in (\n    SELECT domain_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{domain_param}}]]\n  )  \nAND criteria in (\n    SELECT criteria_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{criteria_param}}]]\n  )\nGROUP BY criteria_level,criteria;",
+        "query": "SELECT criteria_level,criteria as \"Criteria\",count(distinct ${entityColumnName}) as \"Percentage wise distribution of count of ${entityType}\"\nFROM ${domainTable}\nWHERE 1 =1 \nAND parent_one_name in (\n    SELECT parent_one_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{state_param}}]]\n  )\nAND parent_two_name in (\n    SELECT parent_two_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{district_param}}]]\n  )\nAND parent_three_name in (\n    SELECT parent_three_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{block_param}}]]\n  )\nAND parent_four_name in (\n    SELECT parent_four_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{cluster_param}}]]\n  )  \nAND parent_five_name in (\n    SELECT parent_five_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{org_param}}]]\n  ) \nAND domain in (\n    SELECT domain_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{domain_param}}]]\n  )  \nAND criteria in (\n    SELECT criteria_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{criteria_param}}]]\n  )\nAND entity_name in (\n    SELECT entity_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{entity_param}}]]\n  )\nGROUP BY criteria_level,criteria;",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -95,6 +95,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -210,6 +224,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -292,6 +319,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question-Domain/Question-Report/json/graph/domain-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question-Domain/Question-Report/json/graph/domain-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT domain_level,domain as \"Domain\",count(distinct ${entityColumnId}) AS \"Percentage wise distribution of count of ${entityType}\"\nFROM ${domainTable}\nWHERE 1 = 1\nAND parent_one_name in (\n    SELECT parent_one_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{state_param}}]]\n  )\nAND parent_two_name in (\n    SELECT parent_two_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{district_param}}]]\n  )\nAND parent_three_name in (\n    SELECT parent_three_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{block_param}}]]\n  )\nAND parent_four_name in (\n    SELECT parent_four_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{cluster_param}}]]\n  )  \nAND parent_five_name in (\n    SELECT parent_five_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{org_param}}]]\n  ) \nAND domain in (\n    SELECT domain_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{domain_param}}]]\n  )  \nAND criteria in (\n    SELECT criteria_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{criteria_param}}]]\n  )\nGROUP BY domain_level,domain\norder by domain",
+        "query": "SELECT domain_level,domain as \"Domain\",count(distinct ${entityColumnId}) AS \"Percentage wise distribution of count of ${entityType}\"\nFROM ${domainTable}\nWHERE 1 = 1\nAND parent_one_name in (\n    SELECT parent_one_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{state_param}}]]\n  )\nAND parent_two_name in (\n    SELECT parent_two_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{district_param}}]]\n  )\nAND parent_three_name in (\n    SELECT parent_three_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{block_param}}]]\n  )\nAND parent_four_name in (\n    SELECT parent_four_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{cluster_param}}]]\n  )  \nAND parent_five_name in (\n    SELECT parent_five_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{org_param}}]]\n  ) \nAND domain in (\n    SELECT domain_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{domain_param}}]]\n  )  \nAND criteria in (\n    SELECT criteria_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{criteria_param}}]]\n  )\nAND entity_name in (\n    SELECT entity_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{entity_param}}]]\n  )\nGROUP BY domain_level,domain\norder by domain",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -95,6 +95,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -210,6 +224,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -292,6 +319,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question-Domain/Question-Report/json/table/domain-criteria-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question-Domain/Question-Report/json/table/domain-criteria-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT user_id as \"UUID\",\nuser_roles as \"User Roles\",\nparent_one_name as \"State\",\nparent_two_name as \"District\",\nparent_three_name as \"Block\",\nparent_four_name as \"Cluster\",\norg_name as \"Organisation\",\nprogram_name as \"Program\",\nprogram_id as \"Program Id\",\nobservation_name as \"Observation\",\nobservation_id as \"Observation Id\",\nsubmission_id as \"Observation Submission Id\",\ncompleted_date as \"Submission Date\",\ndomain  as \"Domain\",\ndomain_level as \"Domain Level\",\ncriteria as \"Criteria\",\ncriteria_level as \"criteria_level\"\nFROM ${domainTable}\nWHERE 1 =1 \nAND parent_one_name in (\n    SELECT parent_one_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{state_param}}]]\n  )\nAND parent_two_name in (\n    SELECT parent_two_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{district_param}}]]\n  )\nAND parent_three_name in (\n    SELECT parent_three_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{block_param}}]]\n  )\nAND parent_four_name in (\n    SELECT parent_four_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{cluster_param}}]]\n  )  \nAND parent_five_name in (\n    SELECT parent_five_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{org_param}}]]\n  ) \nAND domain in (\n    SELECT domain_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{domain_param}}]]\n  )  \nAND criteria in (\n    SELECT criteria_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{criteria_param}}]]\n  );",
+        "query": "SELECT user_id as \"UUID\",\nuser_roles as \"User Roles\",\nparent_one_name as \"State\",\nparent_two_name as \"District\",\nparent_three_name as \"Block\",\nparent_four_name as \"Cluster\",\norg_name as \"Organisation\",\nprogram_name as \"Program\",\nprogram_id as \"Program Id\",\nobservation_name as \"Observation\",\nobservation_id as \"Observation Id\",\nsubmission_id as \"Observation Submission Id\",\ncompleted_date as \"Submission Date\",\ndomain  as \"Domain\",\ndomain_level as \"Domain Level\",\ncriteria as \"Criteria\",\ncriteria_level as \"criteria_level\"\nFROM ${domainTable}\nWHERE 1 =1 \nAND parent_one_name in (\n    SELECT parent_one_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{state_param}}]]\n  )\nAND parent_two_name in (\n    SELECT parent_two_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{district_param}}]]\n  )\nAND parent_three_name in (\n    SELECT parent_three_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{block_param}}]]\n  )\nAND parent_four_name in (\n    SELECT parent_four_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{cluster_param}}]]\n  )  \nAND parent_five_name in (\n    SELECT parent_five_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{org_param}}]]\n  ) \nAND domain in (\n    SELECT domain_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{domain_param}}]]\n  )  \nAND criteria in (\n    SELECT criteria_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{criteria_param}}]]\n  )\nAND entity_name in (\n    SELECT entity_name\n    FROM ${questionTable}\n    WHERE 1 = 1 [[AND {{entity_param}}]]\n  );",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -95,6 +95,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -210,6 +224,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -292,6 +319,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/date-chart/date-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/date-chart/date-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT TO_CHAR(labels::TIMESTAMP, 'YYYY-MM-DD') AS \"date\",COUNT(*) AS \"Total count of users\"\nFROM ${questionTable}\nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\nAND question_type = 'date'\nAND question_id = ${questionId}\nGROUP BY TO_CHAR(labels::TIMESTAMP, 'YYYY-MM-DD')\nORDER BY \"date\";",
+        "query": "SELECT TO_CHAR(labels::TIMESTAMP, 'YYYY-MM-DD') AS \"date\",COUNT(*) AS \"Total count of users\"\nFROM ${questionTable}\nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{entity_param}}]]\nAND question_type = 'date'\nAND question_id = ${questionId}\nGROUP BY TO_CHAR(labels::TIMESTAMP, 'YYYY-MM-DD')\nORDER BY \"date\";",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -85,6 +85,20 @@
             "dimension": [
               "field",
               485,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
               null
             ],
             "widget-type": "string/=",
@@ -173,6 +187,19 @@
         ],
         "name": "Org Param",
         "slug": "org_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -244,6 +271,17 @@
           [
             "template-tag",
             "org_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/multiselect-chart/multiselect-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/multiselect-chart/multiselect-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT \n    UNNEST(STRING_TO_ARRAY(labels, '|')) AS \"Answers\", \n    COUNT(DISTINCT submission_id) AS \"User Count\"\nFROM ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\nAND question_id = ${questionId}\nGROUP BY \"Answers\"\nORDER BY \"User Count\" DESC;",
+        "query": "SELECT \n    UNNEST(STRING_TO_ARRAY(labels, '|')) AS \"Answers\", \n    COUNT(DISTINCT submission_id) AS \"User Count\"\nFROM ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{entity_param}}]]\nAND question_id = ${questionId}\nGROUP BY \"Answers\"\nORDER BY \"User Count\" DESC;",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -85,6 +85,20 @@
             "dimension": [
               "field",
               485,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
               null
             ],
             "widget-type": "string/=",
@@ -173,6 +187,19 @@
         ],
         "name": "Org Param",
         "slug": "org_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -244,6 +271,17 @@
           [
             "template-tag",
             "org_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/number-chart/number-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/number-chart/number-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT \n    COUNT(*) AS \"Total count of users\",\n    labels\nFROM ${questionTable}\nWHERE 1 = 1\nAND question_type = 'number'\nAND question_id = ${questionId}\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\nGROUP BY labels",
+        "query": "SELECT \n    COUNT(*) AS \"Total count of users\",\n    labels\nFROM ${questionTable}\nWHERE 1 = 1\nAND question_type = 'number'\nAND question_id = ${questionId}\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{entity_param}}]]\nGROUP BY labels",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -85,6 +85,20 @@
             "dimension": [
               "field",
               485,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
               null
             ],
             "widget-type": "string/=",
@@ -173,6 +187,19 @@
         ],
         "name": "Org Param",
         "slug": "org_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -244,6 +271,17 @@
           [
             "template-tag",
             "org_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/radio-chart/radio-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/radio-chart/radio-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT labels AS Rating, COUNT(*) AS \"Total count of users\"\nFROM ${questionTable} \nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\nand question_type = 'radio'\nand question_id = ${questionId}\nGROUP BY labels\nORDER BY labels;",
+        "query": "SELECT labels AS Rating, COUNT(*) AS \"Total count of users\"\nFROM ${questionTable} \nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{entity_param}}]]\nand question_type = 'radio'\nand question_id = ${questionId}\nGROUP BY labels\nORDER BY labels;",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -85,6 +85,20 @@
             "dimension": [
               "field",
               485,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
               null
             ],
             "widget-type": "string/=",
@@ -173,6 +187,19 @@
         ],
         "name": "Org Param",
         "slug": "org_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -244,6 +271,17 @@
           [
             "template-tag",
             "org_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/slider-chart/slider-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/slider-chart/slider-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT value AS \"Rating\", COUNT(*) AS \"Total count of users\"\nFROM ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\nAND question_type = 'slider' \nAND question_id = ${questionId}\nAND value is not null AND value <> ''\nGROUP BY value\nORDER BY value;",
+        "query": "SELECT value AS \"Rating\", COUNT(*) AS \"Total count of users\"\nFROM ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{entity_param}}]]\nAND question_type = 'slider' \nAND question_id = ${questionId}\nAND value is not null AND value <> ''\nGROUP BY value\nORDER BY value;",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -85,6 +85,20 @@
             "dimension": [
               "field",
               485,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
               null
             ],
             "widget-type": "string/=",
@@ -173,6 +187,19 @@
         ],
         "name": "Org Param",
         "slug": "org_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -244,6 +271,17 @@
           [
             "template-tag",
             "org_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/table/question-report.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/table/question-report.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "select user_id as \"UUID\",\nuser_roles as \"User Type\",\nparent_one_name as \"State\",\nparent_two_name as \"District\",\nparent_three_name as \"Block\",\nparent_four_name as \"Cluster\",\nparent_five_name as \"School\",\nparent_five_id as \"School Id\",\norg_name as \"Organisation\",\nprogram_name as \"Program\",\nprogram_id as \"Program Id\",\nobservation_name  as \"Observation\",\nobservation_id as \"Observation Id\",\nsubmission_id as \"Observation Submission Id\",\nsubmitted_at as \"Submission Date\",\ndomain_name as \"Domain\",\ncriteria_name as \"Criteria\",\nquestion_id as \"Question Id\",\nquestion_text as \"Question\",\nlabels as \"Question Response Lable\",\nscore as \"Question Score\",\n  (\n    SELECT string_agg(\n      ${evidenceBaseUrl} || trim(value),\n      ', '\n    )\n    FROM unnest(string_to_array(evidence, ',')) AS value\n  ) AS \"Evidences\",\nremarks as \"Remarks\"\nfrom ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]];",
+        "query": "select user_id as \"UUID\",\nuser_roles as \"User Type\",\nparent_one_name as \"State\",\nparent_two_name as \"District\",\nparent_three_name as \"Block\",\nparent_four_name as \"Cluster\",\nparent_five_name as \"School\",\nparent_five_id as \"School Id\",\norg_name as \"Organisation\",\nprogram_name as \"Program\",\nprogram_id as \"Program Id\",\nobservation_name  as \"Observation\",\nobservation_id as \"Observation Id\",\nsubmission_id as \"Observation Submission Id\",\nsubmitted_at as \"Submission Date\",\ndomain_name as \"Domain\",\ncriteria_name as \"Criteria\",\nquestion_id as \"Question Id\",\nquestion_text as \"Question\",\nlabels as \"Question Response Lable\",\nscore as \"Question Score\",\n  (\n    SELECT string_agg(\n      ${evidenceBaseUrl} || trim(value),\n      ', '\n    )\n    FROM unnest(string_to_array(evidence, ',')) AS value\n  ) AS \"Evidences\",\nremarks as \"Remarks\"\nfrom ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{entity_param}}]];",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -85,6 +85,20 @@
             "dimension": [
               "field",
               485,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
               null
             ],
             "widget-type": "string/=",
@@ -173,6 +187,19 @@
         ],
         "name": "Org Param",
         "slug": "org_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -244,6 +271,17 @@
           [
             "template-tag",
             "org_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/text-chart/text-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question-Without-Rubric/Question-Report/json/text-chart/text-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "select user_id as \"User ID\", value AS \"Answer\"\nfrom ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\nAND question_id = ${questionId}\nAND value is not null AND value <> ''",
+        "query": "select user_id as \"User ID\", value AS \"Answer\"\nfrom ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{entity_param}}]]\nAND question_id = ${questionId}\nAND value is not null AND value <> ''",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -85,6 +85,20 @@
             "dimension": [
               "field",
               485,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
               null
             ],
             "widget-type": "string/=",
@@ -173,6 +187,19 @@
         ],
         "name": "Org Param",
         "slug": "org_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -244,6 +271,17 @@
           [
             "template-tag",
             "org_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/date-chart/date-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/date-chart/date-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT TO_CHAR(labels::TIMESTAMP, 'YYYY-MM-DD') AS \"date\",COUNT(*) AS \"Total count of users\"\nFROM ${questionTable}\nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\nAND question_type = 'date'\nAND question_id = ${questionId}\nGROUP BY TO_CHAR(labels::TIMESTAMP, 'YYYY-MM-DD')\nORDER BY \"date\";",
+        "query": "SELECT TO_CHAR(labels::TIMESTAMP, 'YYYY-MM-DD') AS \"date\",COUNT(*) AS \"Total count of users\"\nFROM ${questionTable}\nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\n[[AND {{entity_param}}]]\nAND question_type = 'date'\nAND question_id = ${questionId}\nGROUP BY TO_CHAR(labels::TIMESTAMP, 'YYYY-MM-DD')\nORDER BY \"date\";",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -109,6 +109,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -227,6 +241,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -320,6 +347,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/multiselect-chart/multiselect-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/multiselect-chart/multiselect-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT \n    UNNEST(STRING_TO_ARRAY(labels, '|')) AS \"Answers\", \n    COUNT(DISTINCT submission_id) AS \"User Count\"\nFROM ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\nAND question_id = ${questionId}\nGROUP BY \"Answers\"\nORDER BY \"User Count\" DESC;",
+        "query": "SELECT \n    UNNEST(STRING_TO_ARRAY(labels, '|')) AS \"Answers\", \n    COUNT(DISTINCT submission_id) AS \"User Count\"\nFROM ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\n[[AND {{entity_param}}]]\nAND question_id = ${questionId}\nGROUP BY \"Answers\"\nORDER BY \"User Count\" DESC;",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -95,6 +95,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -200,6 +214,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -282,6 +309,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/number-chart/number-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/number-chart/number-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT \n    COUNT(*) AS \"Total count of users\",\n    labels\nFROM ${questionTable}\nWHERE 1 = 1\nAND question_type = 'number'\nAND question_id = ${questionId}\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\nGROUP BY labels",
+        "query": "SELECT \n    COUNT(*) AS \"Total count of users\",\n    labels\nFROM ${questionTable}\nWHERE 1 = 1\nAND question_type = 'number'\nAND question_id = ${questionId}\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\n[[AND {{entity_param}}]]\nGROUP BY labels",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -83,6 +83,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -175,6 +189,19 @@
         ],
         "name": "Cluster Param",
         "slug": "cluster_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -246,6 +273,17 @@
           [
             "template-tag",
             "cluster_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/radio-chart/radio-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/radio-chart/radio-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT labels AS Rating, COUNT(*) AS \"Total count of users\"\nFROM ${questionTable} \nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\nand question_type = 'radio'\nand question_id = ${questionId}\nGROUP BY labels\nORDER BY labels;",
+        "query": "SELECT labels AS Rating, COUNT(*) AS \"Total count of users\"\nFROM ${questionTable} \nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\n[[AND {{entity_param}}]]\nand question_type = 'radio'\nand question_id = ${questionId}\nGROUP BY labels\nORDER BY labels;",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -95,6 +95,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -200,6 +214,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -282,6 +309,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/slider-chart/slider-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/slider-chart/slider-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT value AS \"Rating\", COUNT(*) AS \"Total count of users\"\nFROM ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\nAND question_type = 'slider' \nAND question_id = ${questionId}\nAND value is not null AND value <> ''\nGROUP BY value\nORDER BY value;",
+        "query": "SELECT value AS \"Rating\", COUNT(*) AS \"Total count of users\"\nFROM ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\n[[AND {{entity_param}}]]\nAND question_type = 'slider' \nAND question_id = ${questionId}\nAND value is not null AND value <> ''\nGROUP BY value\nORDER BY value;",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -95,6 +95,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -200,6 +214,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -282,6 +309,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/table/question-report.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/table/question-report.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "select user_id as \"UUID\",\nuser_roles as \"User Type\",\nparent_one_name as \"State\",\nparent_two_name as \"District\",\nparent_three_name as \"Block\",\nparent_four_name as \"Cluster\",\nparent_five_name as \"School\",\nparent_five_id as \"School Id\",\norg_name as \"Organisation\",\nprogram_name as \"Program\",\nprogram_id as \"Program Id\",\nobservation_name  as \"Observation\",\nobservation_id as \"Observation Id\",\nsubmission_id as \"Observation Submission Id\",\nsubmitted_at as \"Submission Date\",\ndomain_name as \"Domain\",\ncriteria_name as \"Criteria\",\nquestion_id as \"Question Id\",\nquestion_text as \"Question\",\nlabels as \"Question Response Lable\",\nscore as \"Question Score\",\n  (\n    SELECT string_agg(\n      ${evidenceBaseUrl} || trim(value),\n      ', '\n    )\n    FROM unnest(string_to_array(evidence, ',')) AS value\n  ) AS \"Evidences\",\nremarks as \"Remarks\"\nfrom ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]];",
+        "query": "select user_id as \"UUID\",\nuser_roles as \"User Type\",\nparent_one_name as \"State\",\nparent_two_name as \"District\",\nparent_three_name as \"Block\",\nparent_four_name as \"Cluster\",\nparent_five_name as \"School\",\nparent_five_id as \"School Id\",\norg_name as \"Organisation\",\nprogram_name as \"Program\",\nprogram_id as \"Program Id\",\nobservation_name  as \"Observation\",\nobservation_id as \"Observation Id\",\nsubmission_id as \"Observation Submission Id\",\nsubmitted_at as \"Submission Date\",\ndomain_name as \"Domain\",\ncriteria_name as \"Criteria\",\nquestion_id as \"Question Id\",\nquestion_text as \"Question\",\nlabels as \"Question Response Lable\",\nscore as \"Question Score\",\n  (\n    SELECT string_agg(\n      ${evidenceBaseUrl} || trim(value),\n      ', '\n    )\n    FROM unnest(string_to_array(evidence, ',')) AS value\n  ) AS \"Evidences\",\nremarks as \"Remarks\"\nfrom ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\n[[AND {{entity_param}}]];",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -95,6 +95,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -200,6 +214,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -282,6 +309,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/text-chart/text-chart.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Question/Question-Report/json/text-chart/text-chart.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "select user_id as \"User ID\", value AS \"Answer\"\nfrom ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\nAND question_id = ${questionId}\nAND value is not null AND value <> ''",
+        "query": "select user_id as \"User ID\", value AS \"Answer\"\nfrom ${questionTable}\nWHERE 1 = 1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{domain_param}}]]\n[[AND {{criteria_param}}]]\n[[AND {{entity_param}}]]\nAND question_id = ${questionId}\nAND value is not null AND value <> ''",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -95,6 +95,20 @@
             "name": "criteria_param",
             "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
             "display-name": "Criteria Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
             "default": null,
             "dimension": [
               "field",
@@ -200,6 +214,19 @@
         ],
         "name": "Criteria Param",
         "slug": "criteria_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -282,6 +309,17 @@
           [
             "template-tag",
             "criteria_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Status/Status-Report/json/big-number/1_no_of_unique_user_consuming_observation.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Status/Status-Report/json/big-number/1_no_of_unique_user_consuming_observation.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "select count(distinct(user_id)) \nfrom ${statusTable}\nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]",
+        "query": "select count(distinct(user_id)) \nfrom ${statusTable}\nWHERE 1 = 1\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{entity_param}}]]",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -85,6 +85,20 @@
             "dimension": [
               "field",
               485,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
               null
             ],
             "widget-type": "string/=",
@@ -173,6 +187,19 @@
         ],
         "name": "Org Param",
         "slug": "org_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -244,6 +271,17 @@
           [
             "template-tag",
             "org_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Status/Status-Report/json/big-number/2_no_of_unique_user_in_started_status.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Status/Status-Report/json/big-number/2_no_of_unique_user_in_started_status.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "select count(distinct(user_id)) \nfrom ${statusTable}\nWHERE 1 = 1\nAND status_of_submission = 'started'\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]",
+        "query": "select count(distinct(user_id)) \nfrom ${statusTable}\nWHERE 1 = 1\nAND status_of_submission = 'started'\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{entity_param}}]]",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -85,6 +85,20 @@
             "dimension": [
               "field",
               485,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
               null
             ],
             "widget-type": "string/=",
@@ -173,6 +187,19 @@
         ],
         "name": "Org Param",
         "slug": "org_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -244,6 +271,17 @@
           [
             "template-tag",
             "org_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Status/Status-Report/json/big-number/4_no_of_unique_user_in_submitted_status.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Status/Status-Report/json/big-number/4_no_of_unique_user_in_submitted_status.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "select count(distinct(user_id)) \nfrom ${statusTable}\nWHERE 1 = 1\nAND status_of_submission = 'completed'\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]",
+        "query": "select count(distinct(user_id)) \nfrom ${statusTable}\nWHERE 1 = 1\nAND status_of_submission = 'completed'\n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{entity_param}}]]",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -85,6 +85,20 @@
             "dimension": [
               "field",
               485,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
               null
             ],
             "widget-type": "string/=",
@@ -173,6 +187,19 @@
         ],
         "name": "Org Param",
         "slug": "org_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -244,6 +271,17 @@
           [
             "template-tag",
             "org_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation-Status/Status-Report/json/table/status-report.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation-Status/Status-Report/json/table/status-report.json
@@ -6,7 +6,7 @@
       "database": 2,
       "type": "native",
       "native": {
-        "query": "SELECT user_id as \"UUID\",\nuser_roles as \"User Type\",\nparent_one_name as \"State\",\nparent_two_name as \"District\",\nparent_three_name as \"Block\",\nparent_four_name as \"Cluster\",\norg_name as \"Organisation\",\nprogram_name as \"Program\",\nprogram_id as \"Program Id\",\nobservation_name as \"Observation\",\nobservation_id as \"Observation Id\",\nsubmission_id as \"Observation Submission Id\",\nsubmitted_at as \"Submission Date\",\nstatus_of_submission as \"Status Of Subbmission\"\nFROM ${statusTable}\nWHERE 1 =1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]];",
+        "query": "SELECT user_id as \"UUID\",\nuser_roles as \"User Type\",\nparent_one_name as \"State\",\nparent_two_name as \"District\",\nparent_three_name as \"Block\",\nparent_four_name as \"Cluster\",\norg_name as \"Organisation\",\nprogram_name as \"Program\",\nprogram_id as \"Program Id\",\nobservation_name as \"Observation\",\nobservation_id as \"Observation Id\",\nsubmission_id as \"Observation Submission Id\",\nsubmitted_at as \"Submission Date\",\nstatus_of_submission as \"Status Of Subbmission\"\nFROM ${statusTable}\nWHERE 1 =1 \n[[AND {{state_param}}]]\n[[AND {{district_param}}]]\n[[AND {{block_param}}]]\n[[AND {{cluster_param}}]]\n[[AND {{school_param}}]]\n[[AND {{org_param}}]]\n[[AND {{entity_param}}]];",
         "template-tags": {
           "state_param": {
             "type": "dimension",
@@ -85,6 +85,20 @@
             "dimension": [
               "field",
               485,
+              null
+            ],
+            "widget-type": "string/=",
+            "options": null
+          },
+          "entity_param": {
+            "type": "dimension",
+            "name": "entity_param",
+            "id": "ae72528d-cca1-4f18-8d62-bc10b0ae3430",
+            "display-name": "Entity Param",
+            "default": null,
+            "dimension": [
+              "field",
+              1506,
               null
             ],
             "widget-type": "string/=",
@@ -173,6 +187,19 @@
         ],
         "name": "Org Param",
         "slug": "org_param"
+      },
+      {
+        "id": "be72528d-cca1-4f18-8d62-bc10b0ae5430",
+        "type": "string/=",
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
+          ]
+        ],
+        "name": "Entity Param",
+        "slug": "entity_param"
       }
     ]
   },
@@ -244,6 +271,17 @@
           [
             "template-tag",
             "org_param"
+          ]
+        ]
+      },
+      {
+        "parameter_id": "ffbf9c98",
+        "card_id": 1876,
+        "target": [
+          "dimension",
+          [
+            "template-tag",
+            "entity_param"
           ]
         ]
       }

--- a/metabase-jobs/config-data-loader/projectJson/Observation/Observation-Parameter/json/Observation-Domain-Parameter/domain-parameter.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation/Observation-Parameter/json/Observation-Domain-Parameter/domain-parameter.json
@@ -17,7 +17,8 @@
       "c32c8fc5",
       "fbca1e77",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ]
   },
   {
@@ -38,7 +39,8 @@
       "c32c8fc5",
       "fbca1e77",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ]
   },
   {
@@ -59,7 +61,8 @@
       "c32c8fc5",
       "fbca1e77",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ]
   },
   {
@@ -80,7 +83,8 @@
       "c32c8fc5",
       "fbca1e77",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ]
   },
   {
@@ -101,7 +105,8 @@
       "74a10335",
       "fbca1e77",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ]
   },
   {
@@ -120,7 +125,8 @@
       "74a10335",
       "c32c8fc5",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ],
     "isMultiSelect": false
   },
@@ -140,7 +146,8 @@
       "74a10335",
       "c32c8fc5",
       "fbca1e77",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ],
     "isMultiSelect": false
   },
@@ -151,6 +158,27 @@
     "param": "org_param",
     "order": 6,
     "id": "5088d3e5",
+    "type": "string/=",
+    "sectionId": "string",
+    "isMultiSelect": false,
+    "filteringParameters": [
+      "6e5c08dc",
+      "cc7a4cd7",
+      "9e5a09bh",
+      "74a10335",
+      "c32c8fc5",
+      "fbca1e77",
+      "ffbf9c99",
+      "ffbf9c98"
+    ]
+  },
+  {
+    "name": "Select $entity_type",
+    "slug": "select_entity_type",
+    "columnName": "entity_name",
+    "param": "entity_param",
+    "order": 10,
+    "id": "ffbf9c98",
     "type": "string/=",
     "sectionId": "string",
     "isMultiSelect": false,

--- a/metabase-jobs/config-data-loader/projectJson/Observation/Observation-Parameter/json/Observation-Question-Parameter/question-parameter.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation/Observation-Parameter/json/Observation-Question-Parameter/question-parameter.json
@@ -17,7 +17,8 @@
       "c32c8fc5",
       "fbca1e77",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ]
   },
   {
@@ -38,7 +39,8 @@
       "c32c8fc5",
       "fbca1e77",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ]
   },
   {
@@ -59,7 +61,8 @@
       "c32c8fc5",
       "fbca1e77",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ]
   },
   {
@@ -80,7 +83,8 @@
       "c32c8fc5",
       "fbca1e77",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ]
   },
   {
@@ -101,7 +105,8 @@
       "74a10335",
       "fbca1e77",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ]
   },
   {
@@ -120,7 +125,8 @@
       "74a10335",
       "c32c8fc5",
       "ffbf9c99",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ],
     "isMultiSelect": false
   },
@@ -140,7 +146,8 @@
       "74a10335",
       "c32c8fc5",
       "fbca1e77",
-      "5088d3e5"
+      "5088d3e5",
+      "ffbf9c98"
     ],
     "isMultiSelect": false
   },
@@ -151,6 +158,27 @@
     "param": "org_param",
     "order": 6,
     "id": "5088d3e5",
+    "type": "string/=",
+    "sectionId": "string",
+    "isMultiSelect": false,
+    "filteringParameters": [
+      "6e5c08dc",
+      "cc7a4cd7",
+      "9e5a09bh",
+      "74a10335",
+      "c32c8fc5",
+      "fbca1e77",
+      "ffbf9c99",
+      "ffbf9c98"
+    ]
+  },
+  {
+    "name": "Select $entity_type",
+    "slug": "select_entity_type",
+    "columnName": "entity_name",
+    "param": "entity_param",
+    "order": 10,
+    "id": "ffbf9c98",
     "type": "string/=",
     "sectionId": "string",
     "isMultiSelect": false,

--- a/metabase-jobs/config-data-loader/projectJson/Observation/Observation-Parameter/json/Observation-Question-Without-Rubric-Parameter/Question-Without-Rubric-Parameter.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation/Observation-Parameter/json/Observation-Question-Without-Rubric-Parameter/Question-Without-Rubric-Parameter.json
@@ -15,7 +15,8 @@
       "c32c8fc5",
       "74a10335",
       "9e5a09bh",
-      "cc7a4cd7"
+      "cc7a4cd7",
+      "ffbf9c98"
     ]
   },
   {
@@ -34,7 +35,8 @@
       "c32c8fc5",
       "74a10335",
       "9e5a09bh",
-      "6e5c08dc"
+      "6e5c08dc",
+      "ffbf9c98"
     ]
   },
   {
@@ -53,7 +55,8 @@
       "c32c8fc5",
       "74a10335",
       "cc7a4cd7",
-      "6e5c08dc"
+      "6e5c08dc",
+      "ffbf9c98"
     ]
   },
   {
@@ -72,7 +75,8 @@
       "c32c8fc5",
       "9e5a09bh",
       "cc7a4cd7",
-      "6e5c08dc"
+      "6e5c08dc",
+      "ffbf9c98"
     ]
   },
   {
@@ -91,7 +95,8 @@
       "74a10335",
       "9e5a09bh",
       "cc7a4cd7",
-      "6e5c08dc"
+      "6e5c08dc",
+      "ffbf9c98"
     ]
   },
   {
@@ -109,7 +114,28 @@
       "74a10335",
       "9e5a09bh",
       "cc7a4cd7",
-      "6e5c08dc"
+      "6e5c08dc",
+      "ffbf9c98"
+    ]
+  },
+  {
+    "name": "Select $entity_type",
+    "slug": "select_entity_type",
+    "columnName": "entity_name",
+    "param": "entity_param",
+    "order": 10,
+    "id": "ffbf9c98",
+    "type": "string/=",
+    "sectionId": "string",
+    "isMultiSelect": false,
+    "filteringParameters": [
+      "6e5c08dc",
+      "cc7a4cd7",
+      "9e5a09bh",
+      "74a10335",
+      "c32c8fc5",
+      "fbca1e77",
+      "ffbf9c99"
     ]
   }
 ]

--- a/metabase-jobs/config-data-loader/projectJson/Observation/Observation-Parameter/json/Observation-Status-Parameter/status-parameter.json
+++ b/metabase-jobs/config-data-loader/projectJson/Observation/Observation-Parameter/json/Observation-Status-Parameter/status-parameter.json
@@ -15,7 +15,8 @@
       "c32c8fc5",
       "74a10335",
       "9e5a09bh",
-      "cc7a4cd7"
+      "cc7a4cd7",
+      "ffbf9c98"
     ]
   },
   {
@@ -34,7 +35,8 @@
       "c32c8fc5",
       "74a10335",
       "9e5a09bh",
-      "6e5c08dc"
+      "6e5c08dc",
+      "ffbf9c98"
     ]
   },
   {
@@ -53,7 +55,8 @@
       "c32c8fc5",
       "74a10335",
       "cc7a4cd7",
-      "6e5c08dc"
+      "6e5c08dc",
+      "ffbf9c98"
     ]
   },
   {
@@ -72,7 +75,8 @@
       "c32c8fc5",
       "9e5a09bh",
       "cc7a4cd7",
-      "6e5c08dc"
+      "6e5c08dc",
+      "ffbf9c98"
     ]
   },
   {
@@ -91,7 +95,8 @@
       "74a10335",
       "9e5a09bh",
       "cc7a4cd7",
-      "6e5c08dc"
+      "6e5c08dc",
+      "ffbf9c98"
     ]
   },
   {
@@ -109,7 +114,28 @@
       "74a10335",
       "9e5a09bh",
       "cc7a4cd7",
-      "6e5c08dc"
+      "6e5c08dc",
+      "ffbf9c98"
+    ]
+  },
+  {
+    "name": "Select $entity_type",
+    "slug": "select_entity_type",
+    "columnName": "entity_name",
+    "param": "entity_param",
+    "order": 10,
+    "id": "ffbf9c98",
+    "type": "string/=",
+    "sectionId": "string",
+    "isMultiSelect": false,
+    "filteringParameters": [
+      "6e5c08dc",
+      "cc7a4cd7",
+      "9e5a09bh",
+      "74a10335",
+      "c32c8fc5",
+      "fbca1e77",
+      "ffbf9c99"
     ]
   }
 ]

--- a/metabase-jobs/observation-dashboard-creator/src/main/scala/org/shikshalokam/job/observation/dashboard/creator/functions/ObservationMetabaseDashboardFunction.scala
+++ b/metabase-jobs/observation-dashboard-creator/src/main/scala/org/shikshalokam/job/observation/dashboard/creator/functions/ObservationMetabaseDashboardFunction.scala
@@ -257,7 +257,7 @@ class ObservationMetabaseDashboardFunction(config: ObservationMetabaseDashboardC
             val stateNameId: Int = Utils.getTableMetadataId(databaseId, metabaseUtil, observationQuestionTable, "parent_one_name", postgresUtil, createDashboardQuery)
             val districtNameId: Int = Utils.getTableMetadataId(databaseId, metabaseUtil, observationQuestionTable, "parent_two_name", postgresUtil, createDashboardQuery)
             val parametersQuery: String = s"SELECT config FROM $reportConfig WHERE dashboard_name = 'Observation' AND question_type = 'Observation-Question-Parameter'"
-            val (params, diffLevelDict, entityColumnName) = extractParameterDicts(parametersQuery, entityType, databaseId, metabaseUtil, observationQuestionTable, postgresUtil, createDashboardQuery)
+            val (params, diffLevelDict, entityColumnName, _) = extractParameterDicts(parametersQuery, entityType, databaseId, metabaseUtil, observationQuestionTable, postgresUtil, createDashboardQuery)
             val entityColumnId = if (entityColumnName.endsWith("_name")) {
               entityColumnName.replaceAll("_name$", "_id")
             } else {
@@ -298,13 +298,13 @@ class ObservationMetabaseDashboardFunction(config: ObservationMetabaseDashboardC
           if (databaseId != -1) {
             metabaseUtil.syncDatabaseAndRescanValues(databaseId)
             val parametersQuery: String = s"SELECT config FROM $reportConfig WHERE dashboard_name = 'Observation' AND question_type = 'Observation-Question-Without-Rubric-Parameter'"
-            val (params, diffLevelDict, _) = extractParameterDicts(parametersQuery, entityType, databaseId, metabaseUtil, observationQuestionTable, postgresUtil, createDashboardQuery)
+            val (params, diffLevelDict, _, isEntityTypeMatched) = extractParameterDicts(parametersQuery, entityType, databaseId, metabaseUtil, observationQuestionTable, postgresUtil, createDashboardQuery)
             val stateNameId: Int = Utils.getTableMetadataId(databaseId, metabaseUtil, observationQuestionTable, "parent_one_name", postgresUtil, createDashboardQuery)
             val districtNameId: Int = Utils.getTableMetadataId(databaseId, metabaseUtil, observationQuestionTable, "parent_two_name", postgresUtil, createDashboardQuery)
             metabaseUtil.updateColumnCategory(stateNameId, "State")
             metabaseUtil.updateColumnCategory(districtNameId, "City")
             val questionCardIdList = UpdateWithoutRubricQuestionJsonFiles.ProcessAndUpdateJsonFiles(parentCollectionId, databaseId, dashboardId, tabId, observationQuestionTable, metabaseUtil, postgresUtil, reportConfig, params, diffLevelDict, evidenceBaseUrl)
-            UpdateParameters.UpdateAdminParameterFunction(metabaseUtil, parametersQuery, dashboardId, postgresUtil, diffLevelDict)
+            UpdateParameters.UpdateAdminParameterFunction(metabaseUtil, parametersQuery, dashboardId, postgresUtil, diffLevelDict, entityType, isEntityTypeMatched)
             questionCardIdList
           } else {
             println("Database Id returned -1")
@@ -334,7 +334,7 @@ class ObservationMetabaseDashboardFunction(config: ObservationMetabaseDashboardC
         if (databaseId != -1) {
           metabaseUtil.syncDatabaseAndRescanValues(databaseId)
           val parametersQuery: String = s"SELECT config FROM $reportConfig WHERE dashboard_name = 'Observation' AND question_type = 'Observation-Status-Parameter'"
-          val (params, diffLevelDict, _) = extractParameterDicts(parametersQuery, entityType, databaseId, metabaseUtil, observationStatusTable, postgresUtil, createDashboardQuery)
+          val (params, diffLevelDict, _, isEntityTypeMatched) = extractParameterDicts(parametersQuery, entityType, databaseId, metabaseUtil, observationStatusTable, postgresUtil, createDashboardQuery)
           val stateNameId: Int = Utils.getTableMetadataId(databaseId, metabaseUtil, observationStatusTable, "parent_one_name", postgresUtil, createDashboardQuery)
           val districtNameId: Int = Utils.getTableMetadataId(databaseId, metabaseUtil, observationStatusTable, "parent_two_name", postgresUtil, createDashboardQuery)
           metabaseUtil.updateColumnCategory(stateNameId, "State")
@@ -368,7 +368,7 @@ class ObservationMetabaseDashboardFunction(config: ObservationMetabaseDashboardC
         if (databaseId != -1) {
           metabaseUtil.syncDatabaseAndRescanValues(databaseId)
           val parametersQuery: String = s"SELECT config FROM $reportConfig WHERE dashboard_name = 'Observation' AND question_type = 'Observation-Domain-Parameter'"
-          val (params, diffLevelDict, entityColumnName) = extractParameterDicts(parametersQuery, entityType, databaseId, metabaseUtil, observationDomainTable, postgresUtil, createDashboardQuery)
+          val (params, diffLevelDict, entityColumnName, isEntityTypeMatched) = extractParameterDicts(parametersQuery, entityType, databaseId, metabaseUtil, observationDomainTable, postgresUtil, createDashboardQuery)
           val stateNameId: Int = Utils.getTableMetadataId(databaseId, metabaseUtil, observationDomainTable, "parent_one_name", postgresUtil, createDashboardQuery)
           val districtNameId: Int = Utils.getTableMetadataId(databaseId, metabaseUtil, observationDomainTable, "parent_two_name", postgresUtil, createDashboardQuery)
           val entityColumnId = if (entityColumnName.endsWith("_name")) {
@@ -386,7 +386,7 @@ class ObservationMetabaseDashboardFunction(config: ObservationMetabaseDashboardC
             "${entityType}" -> s"""$entityType"""
           )
           val questionCardIdList = UpdateStatusJsonFiles.ProcessAndUpdateJsonFiles(reportConfigQuery, parentCollectionId, databaseId, dashboardId, tabId, metabaseUtil, postgresUtil, params, replacements, diffLevelDict, entityType)
-          UpdateParameters.UpdateAdminParameterFunction(metabaseUtil, parametersQuery, dashboardId, postgresUtil, diffLevelDict)
+          UpdateParameters.UpdateAdminParameterFunction(metabaseUtil, parametersQuery, dashboardId, postgresUtil, diffLevelDict, entityType, isEntityTypeMatched)
           return questionCardIdList
         }
         ListBuffer.empty[Int]
@@ -424,7 +424,7 @@ class ObservationMetabaseDashboardFunction(config: ObservationMetabaseDashboardC
           val databaseId: Int = Utils.getDatabaseId(metabaseDatabase, metabaseUtil)
           val tabId: Int = tabIdMap.getOrElse(dashboardName, -1)
           metabaseUtil.syncDatabaseAndRescanValues(databaseId)
-          val (params, diffLevelDict, _) = extractParameterDicts(parametersQuery, entityType, databaseId, metabaseUtil, observationTable, postgresUtil, createDashboardQuery)
+          val (params, diffLevelDict, _, _) = extractParameterDicts(parametersQuery, entityType, databaseId, metabaseUtil, observationTable, postgresUtil, createDashboardQuery)
           val stateNameId: Int = Utils.getTableMetadataId(databaseId, metabaseUtil, observationStatusTable, "parent_one_name", postgresUtil, createDashboardQuery)
           val districtNameId: Int = Utils.getTableMetadataId(databaseId, metabaseUtil, observationStatusTable, "parent_two_name", postgresUtil, createDashboardQuery)
           metabaseUtil.updateColumnCategory(stateNameId, "State")
@@ -451,41 +451,74 @@ class ObservationMetabaseDashboardFunction(config: ObservationMetabaseDashboardC
       }
     }
 
-    def extractParameterDicts(parametersQuery: String, entityType: String, databaseId: Int, metabaseUtil: MetabaseUtil, tableName: String, postgresUtil: PostgresUtil, createDashboardQuery: String): (Map[String, Int], ListMap[String, String], String) = {
+    def extractParameterDicts(parametersQuery: String, entityType: String, databaseId: Int, metabaseUtil: MetabaseUtil, tableName: String, postgresUtil: PostgresUtil, createDashboardQuery: String): (Map[String, Int], ListMap[String, String], String, Boolean) = {
+
       val DashboardParameter = postgresUtil.fetchData(parametersQuery) match {
         case List(map: Map[_, _]) => map.get("config").map(_.toString).getOrElse("")
         case _ => ""
       }
+
       val mapper = new ObjectMapper()
       val arrayNode = mapper.readTree(DashboardParameter)
-      val removeParamsAfterThis: String = arrayNode.elements().asScala
-        .find(node => Option(node.get("entity_type")).exists(_.asText() == entityType))
-        .flatMap(node => Option(node.get("param")).map(_.asText()))
-        .getOrElse("")
+      println(s"arrayNode: $arrayNode")
+
+      val matchedNodeOpt = arrayNode.elements().asScala.find(
+        node => Option(node.get("entity_type")).exists(_.asText() == entityType)
+      )
+
       val completeMapOfParamAndColumnName: ListMap[String, String] = ListMap(
         arrayNode.elements().asScala
           .map(node => node.get("param").asText() -> node.get("columnName").asText())
           .toSeq: _*
       )
 
-      val entityColumnName: String = completeMapOfParamAndColumnName.getOrElse(removeParamsAfterThis, "")
+      println(s"Complete Map of Param and Column Name: $completeMapOfParamAndColumnName")
 
-      def getTheMapOfParamsAfterRemovingTheEntityParam(completeMapOfParamAndColumnName: ListMap[String, String], removeParamsAfterThis: String): ListMap[String, String] = {
-        val keys = completeMapOfParamAndColumnName.keys.toList
-        val idx = keys.indexOf(removeParamsAfterThis)
-        if (idx == -1) completeMapOfParamAndColumnName
-        else ListMap(keys.drop(idx).map(k => k -> completeMapOfParamAndColumnName(k)): _*)
-      }
+      val (mapOfParamsAfterRemovingBelowEntityParams, _, entityColumnName, isEntityTypeMatched) =
+        matchedNodeOpt match {
+          // Case 1: entityType matches
+          case Some(node) =>
+            val removeParam = node.get("param").asText()
+            val entityCol = completeMapOfParamAndColumnName.getOrElse(removeParam, "")
 
-      val mapOfParamsAfterRemovingBelowEntityParams = getTheMapOfParamsAfterRemovingTheEntityParam(completeMapOfParamAndColumnName, removeParamsAfterThis)
-      val params: Map[String, Int] = mapOfParamsAfterRemovingBelowEntityParams.map { case (key, columnName) =>
-        key -> Utils.getTableMetadataId(databaseId, metabaseUtil, tableName, columnName, postgresUtil, createDashboardQuery)
-      }
+            val keys = completeMapOfParamAndColumnName.keys.toList
+            val idx = keys.indexOf(removeParam)
+
+            val filtered =
+              if (idx == -1) completeMapOfParamAndColumnName
+              else ListMap(keys.drop(idx).map(k => k -> completeMapOfParamAndColumnName(k)): _*)
+
+            val filteredWithoutEntity = filtered.filterNot { case (k, _) => k == "entity_param" }
+
+            (filteredWithoutEntity, removeParam, entityCol, true)
+
+          // Case 2: entityType not found
+          case None =>
+            val keepKeys = Seq("domain_param", "criteria_param", "entity_param")
+            val filtered = ListMap(keepKeys.flatMap(k =>
+              completeMapOfParamAndColumnName.get(k).map(v => k -> v)
+            ): _*)
+
+            (filtered, "entity_param", "entity_name", true)
+        }
+
+      val params: Map[String, Int] =
+        mapOfParamsAfterRemovingBelowEntityParams.map { case (key, columnName) =>
+          key -> Utils.getTableMetadataId(databaseId, metabaseUtil, tableName, columnName, postgresUtil, createDashboardQuery)
+        }
+
       val mapOfRemovedParams: ListMap[String, String] =
-        if (mapOfParamsAfterRemovingBelowEntityParams.isEmpty) ListMap.empty
-        else completeMapOfParamAndColumnName.filterNot { case (k, v) => mapOfParamsAfterRemovingBelowEntityParams.contains(k) && mapOfParamsAfterRemovingBelowEntityParams(k) == v }
-      (params, mapOfRemovedParams, entityColumnName)
+        completeMapOfParamAndColumnName.filterNot {
+          case (k, v) => mapOfParamsAfterRemovingBelowEntityParams.contains(k) &&
+            mapOfParamsAfterRemovingBelowEntityParams(k) == v
+        }
+      println(s"Params: $params")
+      println(s"Removed Params: $mapOfRemovedParams")
+      println(s"Entity Column Name: $entityColumnName")
+      println(s"Is Entity Type Matched: $isEntityTypeMatched")
+      (params, mapOfRemovedParams, entityColumnName, isEntityTypeMatched)
     }
+
 
     def validateCollection(collectionName: String, reportFor: String, reportId: Option[String] = None): (Boolean, Int) = {
       val mapper = new ObjectMapper()

--- a/metabase-jobs/observation-dashboard-creator/src/main/scala/org/shikshalokam/job/observation/dashboard/creator/functions/UpdateParameters.scala
+++ b/metabase-jobs/observation-dashboard-creator/src/main/scala/org/shikshalokam/job/observation/dashboard/creator/functions/UpdateParameters.scala
@@ -78,7 +78,7 @@ object UpdateParameters {
     println(s"----------------Successfully updated State dashboard parameter----------------")
   }
 
-  def UpdateAdminParameterFunction(metabaseUtil: MetabaseUtil, parametersQuery: String, dashboardId: Int, postgresUtil: PostgresUtil, diffLevelDict: Map[String, String]): Unit = {
+  def UpdateAdminParameterFunction(metabaseUtil: MetabaseUtil, parametersQuery: String, dashboardId: Int, postgresUtil: PostgresUtil, diffLevelDict: Map[String, String], entityType: String, isEntityTypeMatched: Boolean): Unit = {
     println(s"-----------Started Processing Admin dashboard parameter ------------")
 
     val objectMapper = new ObjectMapper()
@@ -106,6 +106,12 @@ object UpdateParameters {
     // Step 3: Remove specified keys from each dict
     sortedParams.foreach { obj =>
       keysToRemove.foreach(obj.remove)
+      if (isEntityTypeMatched) {
+        val name = obj.path("name").asText()
+        if (name.contains("$entity_type")) {
+          obj.put("name", name.replace("$entity_type", entityType))
+        }
+      }
     }
     val resultArray = objectMapper.createArrayNode()
     sortedParams.foreach(resultArray.add)


### PR DESCRIPTION
1. Addressed ticket [3438](https://katha.shikshalokam.org/bug-view-3438.html) :  [R1.0.0 SAAS_QA_MD] Customised Entity type and entities not reflecting on metabase reports.
2. Added the logic to create the customized entity filter on the dashboard .
3. Updated the observation-related JSONs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an “Entity” filter across Observation Domain, Question (with/without rubric), and Status reports (big number, charts, tables).
  - Added a new dashboard parameter “Select [Entity]” enabling entity-level filtering across relevant cards.

- Improvements
  - Dynamic parameter label now replaces “$entity_type” with the actual entity type in dashboards.
  - Enhanced filter interoperability so location, organization, domain, and criteria filters work seamlessly with the new Entity filter.

- Chores
  - Updated dashboard parameter mappings to expose and connect the new Entity filter throughout affected cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->