### PR TITLE
removed the orgName from the program collection

### DIFF
--- a/metabase-jobs/observation-dashboard-creator/src/main/scala/org/shikshalokam/job/observation/dashboard/creator/functions/ObservationMetabaseDashboardFunction.scala
+++ b/metabase-jobs/observation-dashboard-creator/src/main/scala/org/shikshalokam/job/observation/dashboard/creator/functions/ObservationMetabaseDashboardFunction.scala
@@ -96,7 +96,7 @@ class ObservationMetabaseDashboardFunction(config: ObservationMetabaseDashboardC
       val programExternalId = resultMap.get("program_external_id").map(_.toString).getOrElse("")
       val solutionDescription = resultMap.get("description").map(_.toString).getOrElse("")
 
-      val programCollectionName = s"$programName [org : $orgId]"
+      val programCollectionName = s"$programName"
       val solutionCollectionName = s"$solutionName [Observation]"
 
       var tabList: List[String] = List()
@@ -237,7 +237,7 @@ class ObservationMetabaseDashboardFunction(config: ObservationMetabaseDashboardC
       }
 
       def createProgramCollection(programCollectionName: String, targetedProgramId: String, programExternalId: String, programDescription: String, reportFor: String): Int = {
-        val programCollectionDescription = s"Program Id: $targetedProgramId\n\nProgram External Id: $programExternalId\n\nCollection For: $reportFor\n\nProgram Description: $programDescription"
+        val programCollectionDescription = s"Program Id: $targetedProgramId\n\nProgram External Id: $programExternalId\n\nCreator Organisation: $orgId\n\nCollection For: $reportFor\n\nProgram Description: $programDescription"
         val programCollectionId: Int = Utils.createCollection(programCollectionName, programCollectionDescription, metabaseUtil)
         if (programCollectionId != -1) {
           val programMetadataJson = new ObjectMapper().createArrayNode().add(new ObjectMapper().createObjectNode().put("collectionId", programCollectionId).put("collectionName", programCollectionName).put("Collection For", reportFor))
@@ -261,7 +261,7 @@ class ObservationMetabaseDashboardFunction(config: ObservationMetabaseDashboardC
       }
 
       def createProgramCollectionInsideAdmin(adminCollectionId: Int, targetedProgramId: String, externalId: String, programCollectionName: String, programCollectionDescription: String, reportFor: String): Int = {
-        val programDescription = s"Program Id: $targetedProgramId\n\nExternal Id: $externalId\n\nCollection For: $reportFor\n\nProgram Description: $programCollectionDescription"
+        val programDescription = s"Program Id: $targetedProgramId\n\nProgram External Id: $externalId\n\nCreator Organisation: $orgId\n\nCollection For: $reportFor\n\nProgram Description: $programCollectionDescription"
         val programCollectionId = Utils.createCollection(programCollectionName.take(100), programDescription.take(255), metabaseUtil, Some(adminCollectionId))
         val programMetadataJson = new ObjectMapper().createArrayNode().add(new ObjectMapper().createObjectNode().put("collectionId", programCollectionId).put("collectionName", programCollectionName).put("Collection For", reportFor))
         val programMetadataJsonString = programMetadataJson.toString.replace("'", "''")

--- a/metabase-jobs/project-dashboard-creator/src/main/scala/org/shikshalokam/job/dashboard/creator/functions/ProjectMetabaseDashboardFunction.scala
+++ b/metabase-jobs/project-dashboard-creator/src/main/scala/org/shikshalokam/job/dashboard/creator/functions/ProjectMetabaseDashboardFunction.scala
@@ -210,8 +210,8 @@ class ProjectMetabaseDashboardFunction(config: ProjectMetabaseDashboardConfig)(i
          */
         println("\n-->> Process Admin Programs Collection and project solution Dashboard")
         if (targetedSolutionId.nonEmpty && solutionName.nonEmpty && targetedProgramId.nonEmpty && programName.nonEmpty) {
-          val programCollectionName = s"$programName [org : $orgId]"
-          val programCollectionDescription = s"Program Id: $targetedProgramId\n\nProgram External Id: $programExternalId\n\nCollection For: Admin\n\nProgram Description: $programDescription"
+          val programCollectionName = s"$programName"
+          val programCollectionDescription = s"Program Id: $targetedProgramId\n\nProgram External Id: $programExternalId\n\nCreator Organisation: $orgId\n\nCollection For: Admin\n\nProgram Description: $programDescription"
           val solutionCollectionName = s"$solutionName [Project]"
           val solutionCollectionDescription = s"Solution Id: $targetedSolutionId\n\nSolution External Id: $solutionExternalId\n\nCollection For: Admin\n\nSolution Description: $solutionDescription"
 
@@ -244,8 +244,8 @@ class ProjectMetabaseDashboardFunction(config: ProjectMetabaseDashboardConfig)(i
          */
         println("\n-->> Process Program Manager Collection and project solution Dashboard")
         if (targetedSolutionId.nonEmpty && solutionName.nonEmpty && targetedProgramId.nonEmpty && programName.nonEmpty) {
-          val programCollectionName = s"$programName [org : $orgId]"
-          val programCollectionDescription = s"Program Id: $targetedProgramId\n\nProgram External Id: $programExternalId\n\nCollection For: Program Manager\n\nProgram Description: $programDescription"
+          val programCollectionName = s"$programName"
+          val programCollectionDescription = s"Program Id: $targetedProgramId\n\nProgram External Id: $programExternalId\n\nCreator Organisation: $orgId\n\nCollection For: Program Manager\n\nProgram Description: $programDescription"
           val solutionCollectionName = s"$solutionName [Project]"
           val solutionCollectionDescription = s"Solution Id: $targetedSolutionId\n\nSolution External Id: $solutionExternalId\n\nCollection For: Program Manager\n\nSolution Description: $solutionDescription"
 

--- a/metabase-jobs/survey-dashboard-creator/src/main/scala/org/shikshalokam/job/survey/dashboard/creator/functions/SurveyMetabaseDashboardFunction.scala
+++ b/metabase-jobs/survey-dashboard-creator/src/main/scala/org/shikshalokam/job/survey/dashboard/creator/functions/SurveyMetabaseDashboardFunction.scala
@@ -93,7 +93,7 @@ class SurveyMetabaseDashboardFunction(config: SurveyMetabaseDashboardConfig)(imp
       val programName = postgresUtil.fetchData(s"""SELECT entity_name from $metaDataTable where entity_id = '$targetedProgramId'""").collectFirst { case map: Map[_, _] => map.get("entity_name").map(_.toString).getOrElse("") }.getOrElse("")
 
       val orgId = postgresUtil.fetchData(s"""SELECT org_id FROM $solutions WHERE program_id = '$targetedProgramId' AND org_id IS NOT NULL AND TRIM(org_id) <> '' LIMIT 1 """).collectFirst { case map: Map[_, _] => map.getOrElse("org_id", "").toString }.getOrElse("")
-      val programCollectionName = s"$programName [org : $orgId]"
+      val programCollectionName = s"$programName"
       val solutionCollectionName = s"$solutionName [Survey]"
       val tabList: List[String] = List("Status Report", "Question Report", "Status CSV", "Question CSV")
 
@@ -129,7 +129,7 @@ class SurveyMetabaseDashboardFunction(config: SurveyMetabaseDashboardConfig)(imp
                 }
               } else {
                 println(s"=====> $programCollectionName collection is not present, creating $programCollectionName collection for Admin ......")
-                val programCollectionId = createProgramCollectionInsideAdmin(adminCollectionId, targetedProgramId, programExternalId, s"$programName [org : $orgId]", programDescription, "Admin")
+                val programCollectionId = createProgramCollectionInsideAdmin(adminCollectionId, targetedProgramId, programExternalId, programCollectionName, programDescription, "Admin")
                 val surveyCollectionId = createSurveyCollectionInsideProgram(programCollectionId, targetedSolutionId, solutionExternalId, s"$solutionName [Survey]", solutionDescription, "Admin")
                 val dashboardId: Int = Utils.createDashboard(surveyCollectionId, s"Survey Dashboard", dashboardDescription, metabaseUtil)
                 val tabIdMap = Utils.createTabs(dashboardId, tabList, metabaseUtil)
@@ -139,7 +139,7 @@ class SurveyMetabaseDashboardFunction(config: SurveyMetabaseDashboardConfig)(imp
             } else {
               println(s"=====> Programs Collection is not present, creating Programs Collection ......")
               val adminCollectionId = createAdminCollection
-              val programCollectionId = createProgramCollectionInsideAdmin(adminCollectionId, targetedProgramId, programExternalId, s"$programName [org : $orgId]", programDescription, "Admin")
+              val programCollectionId = createProgramCollectionInsideAdmin(adminCollectionId, targetedProgramId, programExternalId, programCollectionName, programDescription, "Admin")
               val surveyCollectionId = createSurveyCollectionInsideProgram(programCollectionId, targetedSolutionId, solutionExternalId, s"$solutionName [Survey]", solutionDescription, "Admin")
               val dashboardId: Int = Utils.createDashboard(surveyCollectionId, s"Survey Dashboard", dashboardDescription, metabaseUtil)
               val tabIdMap = Utils.createTabs(dashboardId, tabList, metabaseUtil)
@@ -220,7 +220,7 @@ class SurveyMetabaseDashboardFunction(config: SurveyMetabaseDashboardConfig)(imp
       }
 
       def createProgramCollection(programCollectionName: String, targetedProgramId: String, programExternalId: String, programDescription: String, reportFor: String): Int = {
-        val programCollectionDescription = s"Program Id: $targetedProgramId\n\nProgram External Id: $programExternalId\n\nCollection For: $reportFor\n\nProgram Description: $programDescription"
+        val programCollectionDescription = s"Program Id: $targetedProgramId\n\nProgram External Id: $programExternalId\n\nCreator Organisation: $orgId\n\nCollection For: $reportFor\n\nProgram Description: $programDescription"
         val programCollectionId: Int = Utils.createCollection(programCollectionName, programCollectionDescription, metabaseUtil)
         if (programCollectionId != -1) {
           val programMetadataJson = new ObjectMapper().createArrayNode().add(new ObjectMapper().createObjectNode().put("collectionId", programCollectionId).put("collectionName", programCollectionName).put("Collection For", reportFor))
@@ -235,7 +235,7 @@ class SurveyMetabaseDashboardFunction(config: SurveyMetabaseDashboardConfig)(imp
       }
 
       def createProgramCollectionInsideAdmin(adminCollectionId: Int, targetedProgramId: String, programExternalId: String, programCollectionName: String, programDescription: String, reportFor: String): Int = {
-        val programCollectionDescription = s"Program Id: $targetedProgramId\n\nExternal Id: $programExternalId\n\nCollection For: $reportFor\n\nProgram Description: $programDescription"
+        val programCollectionDescription = s"Program Id: $targetedProgramId\n\nExternal Id: $programExternalId\n\nCreator Organisation: $orgId\n\nCollection For: $reportFor\n\nProgram Description: $programDescription"
         val programCollectionId = Utils.createCollection(programCollectionName, programCollectionDescription, metabaseUtil, Some(adminCollectionId))
         val programMetadataJson = new ObjectMapper().createArrayNode().add(new ObjectMapper().createObjectNode().put("collectionId", programCollectionId).put("collectionName", programCollectionName).put("Collection For", reportFor))
         val programMetadataJsonString = programMetadataJson.toString.replace("'", "''")


### PR DESCRIPTION
## Bug Fix: Duplicate Program Folder Collections

**Link:** [[Bug #3988](https://katha.shikshalokam.org/bug-view-3988.html)](https://katha.shikshalokam.org/bug-view-3988.html)
**Issue:** Two or more program folder collections were being created when the same program was rolled out for multiple organisations.

### Changes Implemented

1. Removed the organisation name from the program collection name.
2. Added the program creator’s organisation name to the program collection description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified dashboard collection naming by removing organization identifiers from program collection names
  * Enhanced metadata tracking to explicitly include creator organization information in collection descriptions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->